### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 
 [MCP server](https://modelcontextprotocol.io/introduction) for secure command-line interactions on Windows systems, enabling controlled access to PowerShell, CMD, Git Bash shells, and remote systems via SSH. It allows MCP clients (like [Claude Desktop](https://claude.ai/download)) to perform operations on your system, similar to [Open Interpreter](https://github.com/OpenInterpreter/open-interpreter).
 
+<a href="https://glama.ai/mcp/servers/5hiwtoqo31">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/5hiwtoqo31/badge" alt="Windows CLI Server MCP server" />
+</a>
+
 >[!IMPORTANT]
 > This MCP server provides direct access to your system's command line interface and remote systems via SSH. When enabled, it grants access to your files, environment variables, command execution capabilities, and remote server management.
 >


### PR DESCRIPTION
This PR adds a badge for the [Windows CLI MCP Server](https://glama.ai/mcp/servers/5hiwtoqo31) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/5hiwtoqo31">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/5hiwtoqo31/badge" alt="Windows CLI Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.